### PR TITLE
Update record.go allow ttl to be 0

### DIFF
--- a/internal/service/route53/record.go
+++ b/internal/service/route53/record.go
@@ -616,7 +616,7 @@ func resourceRecordUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		}
 	}
 
-	if v, _ := d.GetChange("ttl"); v.(int) != 0 {
+	if v, _ := d.GetChange("ttl"); v != nil {
 		oldRec.TTL = aws.Int64(int64(v.(int)))
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Updated record.go to allow AWS Route53 records to be created with ttl set as 0

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
Closes #36411

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://github.com/hashicorp/terraform-provider-aws/issues/36411


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53    (cached)
```
